### PR TITLE
Implement link integrity warning before workflow transition to private

### DIFF
--- a/artifacts/link-integrity-workflow/understanding-link-integrity.md
+++ b/artifacts/link-integrity-workflow/understanding-link-integrity.md
@@ -92,9 +92,10 @@ The feature was implemented in the `volto-cca-policy` add-on on a dedicated bran
 ### Logic Summary
 - **Trigger**: When the user selects a "Private" transition in the workflow dropdown.
 - **Verification**: The `linkIntegrityCheck` action is dispatched for the current object's UID.
+- **Race Condition Prevention**: The system explicitly waits for the `linkIntegrity.loaded` state to be true before deciding whether to auto-proceed or show the modal. This prevents transitions from executing prematurely due to stale or initial empty state.
 - **Interaction**:
-    - If no incoming links exist, the transition proceeds immediately.
-    - If incoming links are found, a modal appears showing the list of referencing pages.
+    - If no incoming links exist (`breaches.length === 0`), the transition proceeds automatically once the check is loaded.
+    - If incoming links are found, the `WorkflowLinkIntegrityModal` displays the list of referencing pages.
     - The user can either "Cancel" the transition or select "Change state anyway" to proceed.
 
 ## User Story: Testing the Link Integrity Warning

--- a/artifacts/link-integrity-workflow/understanding-link-integrity.md
+++ b/artifacts/link-integrity-workflow/understanding-link-integrity.md
@@ -1,0 +1,120 @@
+# Understanding Link Integrity in Plone and Volto
+
+## Use Case
+A user is editing a content item and decides to change its workflow state to "Private". Before this action is finalized, the system should check if other content items on the website are linking to this item. If such links exist, the user should be informed that these links will effectively "break" for public users (leading to an unauthorized screen).
+
+## Goal
+Identify a programmatic way (ideally a REST API endpoint) to retrieve a list of content items that link to a specific object.
+
+## Research Findings
+
+### 1. `plone.app.linkintegrity`
+- **Mechanism**: Tracks internal links using the `zc.relation` catalog with the relationship name `isReferencing`.
+- **Logic**: Extracts links from Dexterity `RichText` fields and Volto blocks (via `plone.volto`).
+- **Querying**: Provides utility functions in `plone.app.linkintegrity.utils`, notably `getIncomingLinks(obj)`.
+
+### 2. `plone.restapi`
+- **Existing Endpoints**:
+    - **`/@linkintegrity?uids=<UID>`**: Returns "breaches" (items linking to the specified UIDs). This is the same logic used by Plone's delete confirmation screen.
+    - **`/@relations?target=<UID>&relation=isReferencing`**: A more generic endpoint to query the relation catalog. Omitting the `relation` parameter returns all types of incoming relations (including `relatedItems`).
+- **Recommendation**: For the "warn before private" use case, `/@linkintegrity` is highly suitable because it returns structured data specifically designed for notifying users about broken links. However, `/@relations` is better if a simple list of *any* linking item is needed.
+
+### 3. `plone.volto` / Volto Frontend
+- **Backend**: Ensures that internal links within Volto blocks (columns, teasers, etc.) are correctly indexed by `plone.app.linkintegrity`.
+- **Frontend Logic**: 
+    - Volto has a `linkIntegrityCheck` action in `@plone/volto/actions` that calls the `/@linkintegrity` endpoint.
+    - The results are stored in the `linkIntegrity` reducer.
+    - The `ContentsDeleteModal` component in Volto core is the canonical example of how to display these breaches.
+- **Workflow Integration**: The state transition dropdown is managed by the `Workflow` component (`@plone/volto/components/manage/Workflow/Workflow`).
+
+## Recommended Solution
+
+To implement the "warn before private" feature:
+
+1. **Backend Endpoint**: Use `GET /@linkintegrity?uids=<UID>`.
+2. **Frontend Integration (Shadowing)**: 
+    - Shadow the core `Workflow` component by copying it to `frontend/src/addons/volto-cca-policy/src/customizations/volto/components/manage/Workflow/Workflow.jsx`.
+    - Intercept the `onChange` handler in the shadowed component.
+    - If the target state is "Private" (or similar), trigger the `linkIntegrityCheck`.
+    - Show a confirmation modal (similar to `ContentsDeleteModal`) if breaches are found.
+
+## Volto Implementation Details
+
+### Shadowing Path
+```
+frontend/src/addons/volto-cca-policy/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+```
+
+### Logic Hook
+In the shadowed `Workflow.jsx`, modify the `transition` function:
+
+```javascript
+const transition = (selectedOption) => {
+  const isPrivateTransition = ['private', 'reject', 'retract'].includes(selectedOption.value) || 
+                               selectedOption.url.endsWith('/reject') || 
+                               selectedOption.url.endsWith('/retract');
+
+  if (isPrivateTransition) {
+    setPendingOption(selectedOption);
+    dispatch(linkIntegrityCheck([content.UID]));
+    setShowWarningModal(true);
+  } else {
+    executeTransition(selectedOption);
+  }
+};
+```
+
+### Components to reuse
+- `Confirm` from `semantic-ui-react` for the modal wrapper.
+*   **Existing Actions**: `linkIntegrityCheck` from `@plone/volto/actions`.
+*   **Existing Reducers**: `state.linkIntegrity.result` to access the breaches.
+*   **UI Reference**: `ContentsDeleteModal.jsx` in Volto core for the table rendering logic of broken links.
+
+## Final Implementation
+
+The feature was implemented in the `volto-cca-policy` add-on on a dedicated branch.
+
+### Git Branch
+- **Branch Name**: `link-integrity-workflow`
+
+### Files Created/Modified
+1.  **Shadowed Component**: `src/customizations/volto/components/manage/Workflow/Workflow.jsx`
+    - Shadowed from `@plone/volto/components/manage/Workflow/Workflow.jsx`.
+    - Modified to intercept state changes to `private`, `reject`, and `retract`.
+    - Integrated with `linkIntegrityCheck` action and `WorkflowLinkIntegrityModal`.
+2.  **New Component**: `src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx`
+    - A custom confirmation modal that displays link integrity breaches.
+    - Uses `semantic-ui-react` for the UI (Confirm, Table, Loader).
+    - Accesses `state.linkIntegrity.result` to render the list of affected content.
+3.  **Components Index**: `src/components/index.js`
+    - Exported `WorkflowLinkIntegrityModal` for use in the shadowed `Workflow` component.
+
+### Logic Summary
+- **Trigger**: When the user selects a "Private" transition in the workflow dropdown.
+- **Verification**: The `linkIntegrityCheck` action is dispatched for the current object's UID.
+- **Interaction**:
+    - If no incoming links exist, the transition proceeds immediately.
+    - If incoming links are found, a modal appears showing the list of referencing pages.
+    - The user can either "Cancel" the transition or select "Change state anyway" to proceed.
+
+## Example API Call
+```http
+GET /path/to/object/@linkintegrity?uids=<UID>
+```
+Response:
+```json
+[
+  {
+    "@id": "http://localhost:3000/page-to-be-private",
+    "title": "Target Page",
+    "breaches": [
+      {
+        "@id": "http://localhost:3000/source-page",
+        "title": "Source Page",
+        "uid": "..."
+      }
+    ],
+    "items_total": 0
+  }
+]
+```

--- a/artifacts/link-integrity-workflow/understanding-link-integrity.md
+++ b/artifacts/link-integrity-workflow/understanding-link-integrity.md
@@ -93,6 +93,9 @@ The feature was implemented in the `volto-cca-policy` add-on on a dedicated bran
 - **Trigger**: When the user selects a "Private" transition in the workflow dropdown.
 - **Verification**: The `linkIntegrityCheck` action is dispatched for the current object's UID.
 - **Race Condition Prevention**: The system explicitly waits for the `linkIntegrity.loaded` state to be true before deciding whether to auto-proceed or show the modal. This prevents transitions from executing prematurely due to stale or initial empty state.
+- **Activity Indicators (UX)**: 
+    - During the link integrity check, a `Dimmer` and `Loader` are shown within the `WorkflowLinkIntegrityModal` with the message "Checking references...".
+    - During the actual workflow transition execution, a `Dimmer` and `Loader` are shown over the state selection dropdown to indicate that the transition is in progress.
 - **Interaction**:
     - If no incoming links exist (`breaches.length === 0`), the transition proceeds automatically once the check is loaded.
     - If incoming links are found, the `WorkflowLinkIntegrityModal` displays the list of referencing pages.

--- a/artifacts/link-integrity-workflow/understanding-link-integrity.md
+++ b/artifacts/link-integrity-workflow/understanding-link-integrity.md
@@ -97,24 +97,43 @@ The feature was implemented in the `volto-cca-policy` add-on on a dedicated bran
     - If incoming links are found, a modal appears showing the list of referencing pages.
     - The user can either "Cancel" the transition or select "Change state anyway" to proceed.
 
-## Example API Call
-```http
-GET /path/to/object/@linkintegrity?uids=<UID>
-```
-Response:
-```json
-[
-  {
-    "@id": "http://localhost:3000/page-to-be-private",
-    "title": "Target Page",
-    "breaches": [
-      {
-        "@id": "http://localhost:3000/source-page",
-        "title": "Source Page",
-        "uid": "..."
-      }
-    ],
-    "items_total": 0
-  }
-]
-```
+## User Story: Testing the Link Integrity Warning
+
+### Description
+As a Content Editor, I want to be warned when I am about to make a page private if other pages are linking to it, so that I can avoid creating broken links for visitors.
+
+### Acceptance Criteria
+1.  **Positive Case (Breaches Found)**: 
+    - Given a "Target Page" that is published.
+    - Given a "Source Page" that contains a link to "Target Page".
+    - When I go to "Target Page" and select "Make Private" (or "Reject" / "Retract") from the state dropdown.
+    - Then I should see a "Checking references..." loading indicator.
+    - Then I should see a warning modal titled "Warning: Potential broken links".
+    - Then the modal should list "Source Page" as an item that will have a broken link.
+    - When I click "Cancel", the modal should close and the page should remain "Published".
+    - When I click "Change state anyway", the modal should close and the page should transition to "Private".
+
+2.  **Negative Case (No Breaches)**:
+    - Given a "Target Page" that is published and has NO incoming links.
+    - When I select "Make Private" from the state dropdown.
+    - Then I should see a brief "Checking references..." indicator.
+    - Then the page should transition to "Private" immediately without showing a warning modal.
+
+### Test Procedure
+1.  **Setup Content**:
+    - Create a page named "Linked Page" and Publish it.
+    - Create another page named "Referencing Page". 
+    - In "Referencing Page", add a Text block and insert an internal link to "Linked Page". Publish "Referencing Page".
+2.  **Verify Warning**:
+    - Navigate to "Linked Page".
+    - Open the state dropdown in the toolbar.
+    - Select "Make Private".
+    - **Observe**: The "Checking references..." dimmer should appear briefly.
+    - **Verify**: The warning modal should appear listing "Referencing Page".
+3.  **Test Cancellation**:
+    - Click "Cancel" in the modal.
+    - **Verify**: The page is still in "Published" state.
+4.  **Test Confirmation**:
+    - Select "Make Private" again.
+    - Click "Change state anyway" in the modal.
+    - **Verify**: The page state changes to "Private" and a success toast appears.

--- a/artifacts/link-integrity-workflow/volto-block-link-analysis.md
+++ b/artifacts/link-integrity-workflow/volto-block-link-analysis.md
@@ -1,0 +1,63 @@
+# Volto Block Link Discovery Analysis - volto-cca-policy
+
+This document analyzes the custom blocks defined in the `volto-cca-policy` add-on to identify which fields contain internal links and whether they are covered by the standard Plone/Volto link integrity discovery mechanism.
+
+## Standard Discovery Mechanism Recap
+
+As documented in `volto-block-link-discovery.md`, the `GenericBlockLinksRetriever` automatically extracts internal links from the following top-level fields:
+- `url`
+- `href`
+- `preview_image`
+
+Any field not named exactly like one of these, or any link nested within a list or dictionary (unless it's a `blocks` container), requires a specialized retriever on the backend.
+
+## Analysis of volto-cca-policy Blocks
+
+### 1. Blocks Covered by Generic Retriever
+The following blocks use standard field names at the top level and should be automatically tracked.
+
+| Block | Field | Description |
+|---|---|---|
+| `RedirectBlock` | `href` | The target object for the redirection. |
+| `CountryMapObservatory` | `href` | The parent location of all country profiles. |
+| `CollectionStatistics` | `href` | The destination listing page. |
+| `ASTNavigation` | `href` | The main entry page to AST/UAST (top-level). |
+
+### 2. Blocks NOT Covered (Custom Field Names)
+The following blocks use field names that are not recognized by the generic retriever.
+
+| Block | Field | Description |
+|---|---|---|
+| `Listing` (Shadowed) | `linkTo` | Standard Volto listing block uses `linkTo` for the "More..." link. |
+
+### 3. Blocks NOT Covered (Nested Links)
+The following blocks store links within an `object_list`. The generic retriever does not scan inside these lists.
+
+| Block | Field Path | Description |
+|---|---|---|
+| `ContentLinks` | `items[*].source` | A list of hand-picked content items. |
+| `RelevantAceContent` | `items[*].source` | A list of hand-picked content items (assigned items). |
+| `ASTNavigation` | `items[*].href` | Individual navigation steps in the AST map. |
+
+### 4. Special Cases
+
+#### `FlourishEmbedBlock`
+- **Field**: `embed_code` (Textarea)
+- **Status**: Not covered.
+- **Reason**: Contains raw HTML/JS snippets. Discovery would require parsing the HTML for URLs, which is not performed by the standard block retrievers.
+
+#### `TabsBlock` (Spotlight Variation)
+- **Status**: Covered (indirectly).
+- **Reason**: This is a container block. The `NestedBlocksVisitor` handles the recursion into its child blocks, so any links within those children will be discovered normally.
+
+#### `ReadMore`
+- **Status**: No Links.
+- **Reason**: This is a behavioral block that manipulates the DOM of its siblings on the frontend. It does not store links in its own block data.
+
+## Recommendations for Link Integrity
+
+To ensure full coverage for `volto-cca-policy` content, the following actions are recommended:
+
+1.  **Backend Adapters**: Register custom `IBlockFieldLinkIntegrityRetriever` adapters for `ContentLinks`, `RelevantAceContent`, and `ASTNavigation` to extract links from their `items` lists.
+2.  **Field Mapping**: If possible, refactor `ContentLinks` and `RelevantAceContent` to use `href` or `url` instead of `source` for individual items, although a custom retriever is still needed for the list structure.
+3.  **Core Coverage**: Verify if `plone.restapi` or `plone.volto` provides a specialized retriever for the `listing` block's `linkTo` field. If not, one should be added.

--- a/artifacts/link-integrity-workflow/volto-block-link-discovery.md
+++ b/artifacts/link-integrity-workflow/volto-block-link-discovery.md
@@ -1,0 +1,45 @@
+# How Volto Discovers Links in Blocks for Link Integrity
+
+When a content item is saved in Plone, the system needs to know which other internal items it links to, so it can maintain the `zc.relation` catalog (specifically using the `isReferencing` relationship). 
+
+For traditional Plone, this meant parsing HTML in `RichText` fields. For Volto, the content is stored as JSON blocks, requiring a different approach.
+
+## The Plone REST API Foundation
+The discovery of links within JSON blocks is driven by a specific interface defined in `plone.restapi`:
+`plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever`
+
+When a Dexterity object with the `IBlocks` behavior is modified, the backend iterates over its blocks. For each block, it looks for subscribers (adapters) registered to provide `IBlockFieldLinkIntegrityRetriever` for that specific block type (identified by the `@type` property in the JSON).
+
+## Nested Block Support in `plone.volto`
+Volto introduces complex layouts that allow blocks to be nested inside other blocks (e.g., a text block placed inside a column block, or an image inside a slider). 
+
+If Plone only looked at the top-level blocks, it would miss links hidden deep within these nested structures. To solve this, `plone.volto` provides a generic adapter in `src/plone/volto/linkintegrity.py` called `NestedBlockLinkRetriever`.
+
+### How `NestedBlockLinkRetriever` Works:
+
+1. **Generic Registration**: It is registered as a subscriber for *any* block type (`block_type = None`), ensuring it runs for every block parsed by the system.
+2. **Identifying Nested Structures**: When analyzing a block, it explicitly checks for JSON keys that are known to contain arrays of nested blocks in Volto core:
+   - `columns`
+   - `hrefList`
+   - `slides`
+3. **Recursive Extraction**: If it finds a list of blocks under any of these specific keys, it iterates through them.
+4. **Delegation**: For each nested block found, it queries the component registry for `IBlockFieldLinkIntegrityRetriever` subscribers registered for that exact nested block's `@type`.
+5. **Aggregation**: It aggregates all the discovered links from the nested blocks into a single `set()` and returns it.
+
+```python
+# Snippet from plone.volto/linkintegrity.py
+def __call__(self, block):
+    links = set()
+    for nested_name in ("columns", "hrefList", "slides"):
+        nested_blocks = block.get(nested_name, [])
+        if not isinstance(nested_blocks, list):
+            continue
+        for nested_block in nested_blocks:
+            links |= self.retrieveLinks(nested_block)
+    return links
+```
+
+## Summary
+The discovery process is highly extensible. `plone.restapi` provides the mechanism to extract links from standard block fields (like finding a `resolveuid/` in a text block). `plone.volto` builds upon this by providing the `NestedBlockLinkRetriever`, which acts as a recursive crawler. 
+
+Together, they ensure that the Plone backend can walk through a deeply nested JSON block tree, extract all internal references, and keep the link integrity graph completely up to date.

--- a/artifacts/link-integrity-workflow/volto-block-link-discovery.md
+++ b/artifacts/link-integrity-workflow/volto-block-link-discovery.md
@@ -4,50 +4,57 @@ When a content item is saved in Plone, the system needs to know which other inte
 
 For traditional Plone, this meant parsing HTML in `RichText` fields. For Volto, the content is stored as JSON blocks, requiring a recursive discovery mechanism.
 
-## The Foundation: `visit_blocks`
-Discovery starts with a recursive generator in `plone.restapi` called `visit_blocks`. It walks the entire tree of blocks, including nested ones, by delegating the discovery of "children" to multiple `IBlockVisitor` subscribers.
+## Sub-block Storage and Discovery
 
-### How Sub-blocks are Stored and Discovered
-There are three main patterns for storing sub-blocks in Volto:
+Sub-blocks are stored in the JSON data of a parent block using one of two primary patterns. The Plone backend uses a recursive generator called `visit_blocks` (defined in `plone.restapi.blocks`) to walk this tree.
 
-1. **Dictionary Mapping (`blocks`)**:
-   - **Pattern**: `block["blocks"]` or `block["data"]["blocks"]` is a dictionary where keys are UUIDs and values are block data.
-   - **Visitor**: `plone.restapi.blocks.NestedBlocksVisitor` handles these. It yields the `.values()` of these dictionaries.
+### 1. Dictionary Mapping (Key-Value)
+This is the standard Volto pattern for container-like blocks.
+- **Storage Pattern**: A dictionary where keys are UUIDs and values are the sub-block data.
+- **Common Keys**: `blocks` or `data["blocks"]`.
+- **Discovery**: `plone.restapi.blocks.NestedBlocksVisitor` is registered for these keys. It yields each value in the dictionary.
 
-2. **Sequential Lists**:
-   - **Pattern**: `block["columns"]`, `block["slides"]`, or `block["hrefList"]` are lists of block data objects.
-   - **Visitor**: `plone.volto.transforms.NestedBlocksVisitor` handles these core Volto layout keys.
+### 2. Sequential Lists
+This pattern is used by layout-oriented blocks where the order is strictly positional.
+- **Storage Pattern**: A simple list of block data objects.
+- **Core Volto Keys**: `columns`, `slides`, `hrefList`.
+- **Discovery**: `plone.volto.transforms.NestedBlocksVisitor` handles these keys. It iterates through the list and yields each block.
 
-3. **Recursive Children (Slate)**:
-   - **Pattern**: Slate blocks (rich text) store content as a tree of nodes, where each node can have a `children` list. 
-   - **Visitor**: `plone.restapi.blocks.NestedBlocksVisitor` also has special logic for `__somersault__` (plate) blocks to walk these children.
+### 3. Recursive Discovery Logic
+The `visit_blocks` function uses `IBlockVisitor` subscribers to find children. When a visitor yields a sub-block, `visit_blocks` immediately recurses into that sub-block. This ensures that a block tree of any depth (e.g., a Grid containing Columns containing Teasers) is fully flattened during the discovery phase.
 
-## Link Extraction: `IBlockFieldLinkIntegrityRetriever`
-Once `visit_blocks` has identified a specific block data object, the system looks for `IBlockFieldLinkIntegrityRetriever` subscribers to extract internal links from that block's fields.
+## Internal Link Extraction
 
-### Key Fields Used for Linking
-The backend recognizes several fields as potential sources for internal links. A link is identified as internal if it contains the string `resolveuid/`.
+Once a block is discovered, the `BlocksRetriever` (in `plone.restapi.blocks_linkintegrity`) uses `IBlockFieldLinkIntegrityRetriever` subscribers to find internal links within that specific block's fields.
 
-1. **Generic Link Fields**:
-   - **Fields**: `url`, `href`, `preview_image`.
-   - **Implementation**: `GenericBlockLinksRetriever` (in `plone.restapi`).
-   - **Logic**: It automatically checks these keys in *any* block type. It can even find links inside nested lists or dictionaries assigned to these keys.
+### Automatic Link Detection (The Generic Retriever)
+The `GenericBlockLinksRetriever` provides a "zero-configuration" discovery for most custom blocks. It automatically scans the following fields if they contain the `resolveuid/` pattern:
+- `url`
+- `href`
+- `preview_image`
 
-2. **Slate (Rich Text) Links**:
-   - **Implementation**: `SlateBlockLinksRetriever` (in `plone.restapi`).
-   - **Logic**: It deep-walks the Slate JSON tree. It looks for nodes of type `a` or `link`.
-   - **Specific Path**: It extracts the UID from `data.link.internal.internal_link[0]["@id"]` or `data.url`.
+**Note**: If a block uses custom field names for links (e.g., `source`, `target`, `link_to`), they will **NOT** be caught by the generic retriever unless they are specifically registered.
 
-3. **DraftJS (Old Text) Links**:
-   - **Implementation**: `TextBlockLinksRetriever` (in `plone.restapi`).
-   - **Logic**: It parses the `entityMap` looking for `LINK` entities and extracts their `url` or `href` data.
+### Complex Data Extraction
+Some blocks store links deep within complex JSON structures rather than simple top-level strings. These require specialized retrievers:
+
+1. **Slate Blocks (Rich Text)**:
+   - Uses `SlateBlockLinksRetriever`.
+   - Recursively walks the Slate node tree.
+   - Extracts UIDs from `data.link.internal.internal_link[0]["@id"]` and `data.url`.
+
+2. **DraftJS Blocks (Legacy Text)**:
+   - Uses `TextBlockLinksRetriever`.
+   - Parses the `entityMap` for `LINK` entities.
+   - Extracts data from `url` and `href` keys within the entity data.
 
 ## Redundancy and Reliability
-In `plone.volto`, there is an additional `NestedBlockLinkRetriever` (registered for `block_type = None`). This serves as a fail-safe that manually triggers link extraction on the `columns`, `hrefList`, and `slides` keys, ensuring that even if the primary visitor missed something, the link integrity system will still catch it.
+To ensure maximum reliability, `plone.volto` includes a `NestedBlockLinkRetriever` (registered with `block_type = None`). This serves as a fail-safe that manually walks the `columns`, `hrefList`, and `slides` keys to trigger link extraction, providing a second layer of defense for nested layouts.
 
 ## Summary for Developers
-To ensure a custom block supports link integrity:
-- **Use standard keys**: Store your main link in a field named `url` or `href`.
-- **Use standard nesting**: If your block contains sub-blocks, store them in a dictionary under the key `blocks`.
-- **Custom implementation**: If you must use custom keys, register a new `IBlockFieldLinkIntegrityRetriever` for your `@type` in the backend. 
-- **Internal links**: Always store internal links using the `resolveuid/<UID>` format (Volto's `UniversalLink` and `ObjectBrowser` widgets do this by default). 
+To ensure a custom block is correctly tracked by the link integrity system:
+
+1.  **Field Naming**: Prefer naming your link fields `url` or `href` to benefit from the generic retriever.
+2.  **Nesting**: If your block contains sub-blocks, store them in a dictionary under the key `blocks`.
+3.  **Link Format**: Always store internal links using the `resolveuid/<UID>` format.
+4.  **Custom Retrievers**: If you must use unique field names or storage patterns, register a custom `IBlockFieldLinkIntegrityRetriever` adapter for your block's `@type` in the backend.

--- a/artifacts/link-integrity-workflow/volto-block-link-discovery.md
+++ b/artifacts/link-integrity-workflow/volto-block-link-discovery.md
@@ -2,44 +2,52 @@
 
 When a content item is saved in Plone, the system needs to know which other internal items it links to, so it can maintain the `zc.relation` catalog (specifically using the `isReferencing` relationship). 
 
-For traditional Plone, this meant parsing HTML in `RichText` fields. For Volto, the content is stored as JSON blocks, requiring a different approach.
+For traditional Plone, this meant parsing HTML in `RichText` fields. For Volto, the content is stored as JSON blocks, requiring a recursive discovery mechanism.
 
-## The Plone REST API Foundation
-The discovery of links within JSON blocks is driven by a specific interface defined in `plone.restapi`:
-`plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever`
+## The Foundation: `visit_blocks`
+Discovery starts with a recursive generator in `plone.restapi` called `visit_blocks`. It walks the entire tree of blocks, including nested ones, by delegating the discovery of "children" to multiple `IBlockVisitor` subscribers.
 
-When a Dexterity object with the `IBlocks` behavior is modified, the backend iterates over its blocks. For each block, it looks for subscribers (adapters) registered to provide `IBlockFieldLinkIntegrityRetriever` for that specific block type (identified by the `@type` property in the JSON).
+### How Sub-blocks are Stored and Discovered
+There are three main patterns for storing sub-blocks in Volto:
 
-## Nested Block Support in `plone.volto`
-Volto introduces complex layouts that allow blocks to be nested inside other blocks (e.g., a text block placed inside a column block, or an image inside a slider). 
+1. **Dictionary Mapping (`blocks`)**:
+   - **Pattern**: `block["blocks"]` or `block["data"]["blocks"]` is a dictionary where keys are UUIDs and values are block data.
+   - **Visitor**: `plone.restapi.blocks.NestedBlocksVisitor` handles these. It yields the `.values()` of these dictionaries.
 
-If Plone only looked at the top-level blocks, it would miss links hidden deep within these nested structures. To solve this, `plone.volto` provides a generic adapter in `src/plone/volto/linkintegrity.py` called `NestedBlockLinkRetriever`.
+2. **Sequential Lists**:
+   - **Pattern**: `block["columns"]`, `block["slides"]`, or `block["hrefList"]` are lists of block data objects.
+   - **Visitor**: `plone.volto.transforms.NestedBlocksVisitor` handles these core Volto layout keys.
 
-### How `NestedBlockLinkRetriever` Works:
+3. **Recursive Children (Slate)**:
+   - **Pattern**: Slate blocks (rich text) store content as a tree of nodes, where each node can have a `children` list. 
+   - **Visitor**: `plone.restapi.blocks.NestedBlocksVisitor` also has special logic for `__somersault__` (plate) blocks to walk these children.
 
-1. **Generic Registration**: It is registered as a subscriber for *any* block type (`block_type = None`), ensuring it runs for every block parsed by the system.
-2. **Identifying Nested Structures**: When analyzing a block, it explicitly checks for JSON keys that are known to contain arrays of nested blocks in Volto core:
-   - `columns`
-   - `hrefList`
-   - `slides`
-3. **Recursive Extraction**: If it finds a list of blocks under any of these specific keys, it iterates through them.
-4. **Delegation**: For each nested block found, it queries the component registry for `IBlockFieldLinkIntegrityRetriever` subscribers registered for that exact nested block's `@type`.
-5. **Aggregation**: It aggregates all the discovered links from the nested blocks into a single `set()` and returns it.
+## Link Extraction: `IBlockFieldLinkIntegrityRetriever`
+Once `visit_blocks` has identified a specific block data object, the system looks for `IBlockFieldLinkIntegrityRetriever` subscribers to extract internal links from that block's fields.
 
-```python
-# Snippet from plone.volto/linkintegrity.py
-def __call__(self, block):
-    links = set()
-    for nested_name in ("columns", "hrefList", "slides"):
-        nested_blocks = block.get(nested_name, [])
-        if not isinstance(nested_blocks, list):
-            continue
-        for nested_block in nested_blocks:
-            links |= self.retrieveLinks(nested_block)
-    return links
-```
+### Key Fields Used for Linking
+The backend recognizes several fields as potential sources for internal links. A link is identified as internal if it contains the string `resolveuid/`.
 
-## Summary
-The discovery process is highly extensible. `plone.restapi` provides the mechanism to extract links from standard block fields (like finding a `resolveuid/` in a text block). `plone.volto` builds upon this by providing the `NestedBlockLinkRetriever`, which acts as a recursive crawler. 
+1. **Generic Link Fields**:
+   - **Fields**: `url`, `href`, `preview_image`.
+   - **Implementation**: `GenericBlockLinksRetriever` (in `plone.restapi`).
+   - **Logic**: It automatically checks these keys in *any* block type. It can even find links inside nested lists or dictionaries assigned to these keys.
 
-Together, they ensure that the Plone backend can walk through a deeply nested JSON block tree, extract all internal references, and keep the link integrity graph completely up to date.
+2. **Slate (Rich Text) Links**:
+   - **Implementation**: `SlateBlockLinksRetriever` (in `plone.restapi`).
+   - **Logic**: It deep-walks the Slate JSON tree. It looks for nodes of type `a` or `link`.
+   - **Specific Path**: It extracts the UID from `data.link.internal.internal_link[0]["@id"]` or `data.url`.
+
+3. **DraftJS (Old Text) Links**:
+   - **Implementation**: `TextBlockLinksRetriever` (in `plone.restapi`).
+   - **Logic**: It parses the `entityMap` looking for `LINK` entities and extracts their `url` or `href` data.
+
+## Redundancy and Reliability
+In `plone.volto`, there is an additional `NestedBlockLinkRetriever` (registered for `block_type = None`). This serves as a fail-safe that manually triggers link extraction on the `columns`, `hrefList`, and `slides` keys, ensuring that even if the primary visitor missed something, the link integrity system will still catch it.
+
+## Summary for Developers
+To ensure a custom block supports link integrity:
+- **Use standard keys**: Store your main link in a field named `url` or `href`.
+- **Use standard nesting**: If your block contains sub-blocks, store them in a dictionary under the key `blocks`.
+- **Custom implementation**: If you must use custom keys, register a new `IBlockFieldLinkIntegrityRetriever` for your `@type` in the backend. 
+- **Internal links**: Always store internal links using the `resolveuid/<UID>` format (Volto's `UniversalLink` and `ObjectBrowser` widgets do this by default). 

--- a/artifacts/test-fixes/test-fixes-specification.md
+++ b/artifacts/test-fixes/test-fixes-specification.md
@@ -1,0 +1,267 @@
+# Test Fix Specification for volto-cca-policy
+
+> Generated: 2026-05-14
+> Branch: `link-integrity-workflow`
+> Machine timezone: EEST (UTC+3)
+
+## Current State
+
+```
+Test Suites: 4 failed, 57 passed, 61 total
+Tests:       7 failed, 115 passed, 122 total
+Snapshots:   6 failed, 12 passed, 18 total
+```
+
+Four test suites fail for three distinct root causes:
+
+| # | Test File | Failure Type | Root Cause |
+|---|-----------|-------------|------------|
+| 1 | `Spotlight.test.jsx` | Suite won't run | `node:crypto` module resolution (uuid@10 + Jest 26) |
+| 2 | `GeolocationWidget.test.jsx` | Assertion error | Mock path mismatch → real OpenLayers loads in Jest |
+| 3 | `EventView.test.jsx` | 3 snapshot mismatches | Timezone-dependent date formatting |
+| 4 | `CcaEventView.test.jsx` | 3 snapshot mismatches | Timezone-dependent date formatting |
+
+---
+
+## Problem 1: `node:crypto` — Spotlight.test.jsx
+
+### Symptom
+
+```
+ENOENT: no such file or directory, open 'node:crypto'
+    at Runtime.readFile (node_modules/jest-runtime/build/index.js:1987:21)
+    at Object.<anonymous> (node_modules/uuid/dist/rng.js:7:42)
+```
+
+### Root Cause
+
+The `uuid` package (v10.0.0) uses `require('node:crypto')` — the Node.js built-in module protocol prefix (`node:`). Jest 26.6.3 does not understand this protocol and tries to resolve `node:crypto` as a filesystem path, which fails.
+
+`Spotlight.test.jsx` doesn't import `uuid` directly. It's a transitive dependency pulled in through Volto core or one of its addons when the Spotlight component tree is evaluated.
+
+### Proposed Fix
+
+Add a `moduleNameMapper` entry in `jest-addon.config.js` to redirect `node:crypto` to the real Node.js `crypto` module:
+
+**File: `jest-addon.config.js`**
+
+In the `moduleNameMapper` section, add:
+
+```js
+'^node:crypto$': 'crypto',
+```
+
+This tells Jest to resolve `node:crypto` to the standard `crypto` module, which Node.js provides natively and Jest can handle.
+
+**Why this approach:**
+- Minimal: one line in the config, no new files needed.
+- Follows the established pattern used across the addon ecosystem (moduleNameMapper entries in jest-addon.config.js).
+- Does NOT require creating a mock file (the AI agent's `crypto-mock.js` approach).
+- The real `crypto` module works fine in Jest's Node.js environment — it just needs the `node:` prefix stripped.
+
+---
+
+## Problem 2: Mock path mismatch — GeolocationWidget.test.jsx
+
+### Symptom
+
+```
+Invalid lib or bundle name ol,olCondition,olControl,olCoordinate,olEvents,olExtent,olFormat,olGeom,olInteraction,olLayer,olLoadingstrategy,olOverlay,olProj,olRender,olSource,olStyle,olTilegrid
+    at flattenLazyBundle (Loadable/Loadable.js:30:11)
+```
+
+### Root Cause
+
+Two layers of the problem:
+
+**Layer 1 — Webpack vs Jest module resolution mismatch:**
+
+Volto's webpack config uses `RelativeResolverPlugin` (`webpack-plugins/webpack-relative-resolver.js`) which rewrites relative imports into absolute addon-scoped paths at build time. For example, in production:
+
+```
+import MapContainer from './GeolocationWidgetMapContainer'
+```
+
+gets resolved by webpack to:
+
+```
+@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer
+```
+
+Jest does **not** use webpack. It resolves `./GeolocationWidgetMapContainer` as a relative filesystem path. So the two environments resolve the same import line to **different module identifiers**.
+
+**Layer 2 — The test mocks the absolute path, but Jest loads the relative path:**
+
+```js
+// In the test — mocks the absolute (webpack-resolved) path:
+jest.mock(
+  '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer',
+);
+
+// But GeolocationWidget.jsx imports it relatively:
+import MapContainer from './GeolocationWidgetMapContainer';
+```
+
+In Jest, these are two different modules. The mock never applies. The real `GeolocationWidgetMapContainer` loads, which uses the `withOpenLayers` HOC from `volto-openlayers-map`. That HOC calls `useLazyLibs()` to dynamically load OpenLayers bundles, which crashes in Jest's environment.
+
+### Proposed Fix
+
+Two options. **Option A is recommended** because it fixes the source code to match the project convention (the rest of the codebase uses `@eeacms/volto-cca-policy/...` absolute imports — the relative import in `GeolocationWidget.jsx` is the outlier).
+
+---
+
+#### Option A: Change the source code to use the absolute import (recommended)
+
+**File: `src/components/theme/Widgets/GeolocationWidget.jsx`**
+
+Replace:
+
+```js
+import MapContainer from './GeolocationWidgetMapContainer';
+```
+
+With:
+
+```js
+import MapContainer from '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer';
+```
+
+This makes the import consistent with the rest of the codebase (20+ files in this addon use `@eeacms/volto-cca-policy/...` imports). The existing test mock path (`@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer`) will now match in **both** webpack and Jest environments. No test file changes needed.
+
+---
+
+#### Option B: Mock both paths in the test file
+
+If changing the source code is not desired, mock **both** the relative and absolute paths in the test:
+
+**File: `src/components/theme/Widgets/GeolocationWidget.test.jsx`**
+
+Replace:
+
+```js
+jest.mock(
+  '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer',
+);
+```
+
+With:
+
+```js
+const MapContainerMock = () => <div id="map-container-mock" />;
+
+// Mock the relative path (what Jest resolves):
+jest.mock('./GeolocationWidgetMapContainer', () => MapContainerMock);
+
+// Mock the absolute path (what webpack resolves — belt and suspenders):
+jest.mock(
+  '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer',
+  () => MapContainerMock,
+);
+```
+
+**Why Option A is preferred:**
+- One-line source code change, zero test changes.
+- The relative import `./GeolocationWidgetMapContainer` is the **only** relative import to a sibling file within this addon's component tree. Every other internal import in `volto-cca-policy` uses the `@eeacms/volto-cca-policy/...` convention.
+- Fixes the root cause (import inconsistency) rather than working around it in every test file.
+- The existing test mock already targets the correct absolute path — it just never matched because of the relative import in the source.
+
+---
+
+## Problem 3 & 4: Timezone-dependent snapshots — EventView.test.jsx, CcaEventView.test.jsx
+
+### Symptom
+
+```
+- Snapshot  - 2
++ Received  + 2
+
+      <span className="start-time">
+-       3:20 PM
++       6:20 PM
+      </span>
+```
+
+The snapshots expect `3:20 PM` but the test produces `6:20 PM` (a 3-hour offset = UTC vs EEST).
+
+### Root Cause
+
+The test data uses UTC timestamps (e.g., `'2019-06-23T15:20:00+00:00'`). The `EventDetails` component (from `@eeacms/volto-cca-policy/helpers`) formats these dates using JavaScript's built-in `Date` methods, which convert to the **local timezone**. The snapshots were recorded on a machine in UTC (or a timezone with offset 0), but the current test machine is in EEST (UTC+3).
+
+The snapshots contain:
+- `3:20 PM` for `15:20:00+00:00` — correct in UTC
+- `4:20 PM` for `16:20:00+00:00` — correct in UTC
+
+On EEST, these render as `6:20 PM` and `7:20 PM` respectively.
+
+### Proposed Fix
+
+Set `TZ=UTC` for the Jest process so date formatting is deterministic and matches the snapshots. This is done via the `TZ` environment variable, which is the standard, cross-platform way to control timezone in JavaScript tests.
+
+Two approaches (pick one):
+
+**Approach A — Makefile target (recommended):**
+
+Modify the `test` target in `frontend/Makefile` to set `TZ=UTC`:
+
+```makefile
+test: ## Run Jest tests for Volto add-on
+	TZ=UTC RAZZLE_JEST_CONFIG=$(filter-out $@,$(MAKECMDGOALS))/jest-addon.config.js yarn test $(filter-out $@,$(MAKECMDGOALS))
+```
+
+This is the cleanest approach because:
+- It applies to ALL addon tests consistently, preventing the same issue in other addons.
+- No changes needed in individual test files.
+- `TZ=UTC` is the standard approach for timezone-independent tests in CI environments.
+
+**Approach B — jest.setup.js (if Approach A is not preferred):**
+
+Add to `jest.setup.js` (at the top, before any imports that might use Date):
+
+```js
+// Ensure deterministic timezone for snapshot tests
+process.env.TZ = 'UTC';
+```
+
+**Why this approach:**
+- `TZ=UTC` is the established convention for deterministic date formatting in tests.
+- Does not modify the component code or test data.
+- Does not require updating snapshots — the tests will produce the same output as the recorded snapshots.
+- Solves the problem for any future tests that render dates.
+
+---
+
+## Summary of Changes
+
+### Option A (recommended — fix source import)
+
+| File | Change | Lines |
+|------|--------|-------|
+| `jest-addon.config.js` | Add `'^node:crypto$': 'crypto'` to `moduleNameMapper` | +1 |
+| `src/components/theme/Widgets/GeolocationWidget.jsx` | Change `import ... from './GeolocationWidgetMapContainer'` → `import ... from '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer'` | 1 line |
+| `frontend/Makefile` (root) | Add `TZ=UTC` to the `test` target | +1 |
+
+### Option B (mock both paths in test)
+
+| File | Change | Lines |
+|------|--------|-------|
+| `jest-addon.config.js` | Add `'^node:crypto$': 'crypto'` to `moduleNameMapper` | +1 |
+| `src/components/theme/Widgets/GeolocationWidget.test.jsx` | Mock both `./GeolocationWidgetMapContainer` and `@eeacms/.../GeolocationWidgetMapContainer` | ~6 lines |
+| `frontend/Makefile` (root) | Add `TZ=UTC` to the `test` target | +1 |
+
+**No changes needed to:**
+- `jest.setup.js` — the existing setup (with `thunk` middleware) is correct.
+- `EventView.test.jsx` or `CcaEventView.test.jsx` — the snapshots are correct (UTC), the timezone environment is the fix.
+- Any snapshot files — once `TZ=UTC` is set, they will match.
+- `GeolocationWidget.test.jsx` (Option A only) — the existing absolute-path mock already works once the source import is aligned.
+
+## What the Previous AI Agent Did Wrong
+
+The previous attempt made these changes (now stashed/discarded):
+
+1. **`jest.setup.js` — massive rewrite:** Mocked `uuid`, `redux-mock-store`, `useLazyLibs` globally; added `lazyBundles`/`loadables` config; switched to CommonJS `require()`. This was overly invasive — it changed the global test environment for ALL 61 test suites, introducing risk of masking real issues.
+
+2. **`EventView.test.jsx` and `CcaEventView.test.jsx`:** Removed the `jest.mock('Loadable')` + `beforeAll(__setLoadables())` pattern. This was counterproductive — the Loadable mock is the established pattern used by 19+ test files across the addons. Removing it doesn't fix the timezone issue at all.
+
+3. **`GeolocationWidget.test.jsx`:** Added `thunk` middleware to the local `configureStore()` call. Unnecessary — `jest.setup.js` already configures `configureStore([thunk])` globally. Also changed the mock path to `./GeolocationWidgetMapContainer` which fixes the Jest-side resolution but doesn't address the root cause: the source code uses a relative import where the rest of the codebase uses absolute `@eeacms/...` imports, creating a webpack/Jest resolution mismatch.
+
+4. **Created `src/crypto-mock.js`:** An unnecessary file when `moduleNameMapper: 'node:crypto' -> 'crypto'` solves it in one line.

--- a/jest-addon.config.js
+++ b/jest-addon.config.js
@@ -411,6 +411,7 @@ module.exports = {
     'config\\.[jt]sx?$',
   ],
   moduleNameMapper: {
+    '^node:crypto$': '<rootDir>/src/addons/volto-cca-policy/jest-node-crypto-mock.js',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '@plone/volto/cypress': '<rootDir>/node_modules/@plone/volto/cypress',
     '@plone/volto/babel': '<rootDir>/node_modules/@plone/volto/babel',

--- a/jest-node-crypto-mock.js
+++ b/jest-node-crypto-mock.js
@@ -1,0 +1,3 @@
+// Mock for node:crypto protocol — redirects to the real Node.js crypto built-in
+// Used by Jest 26 which doesn't understand the 'node:' protocol prefix
+module.exports = require('crypto');

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ export { default as ImageWidget } from './theme/Widgets/ImageWidget';
 
 // Manage
 export { default as CreateArchivedCopyButton } from './manage/CreateArchivedCopyButton/CreateArchivedCopyButton';
+export { default as WorkflowLinkIntegrityModal } from './manage/Workflow/WorkflowLinkIntegrityModal';
 
 // Views
 export { default as ArchivedVersionListing } from './theme/Views/ArchivedVersionListing';

--- a/src/components/manage/Blocks/ReadMore/ReadMoreView.test.jsx
+++ b/src/components/manage/Blocks/ReadMore/ReadMoreView.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ReadMoreView from './ReadMoreView';
 
 describe('ReadMoreView', () => {
+  /* eslint-disable no-console */
   const originalError = console.error;
   beforeAll(() => {
     console.error = jest.fn((...args) => {
@@ -13,6 +14,7 @@ describe('ReadMoreView', () => {
   afterAll(() => {
     console.error = originalError;
   });
+  /* eslint-enable no-console */
 
   it('renders with default labels and toggles on click', () => {
     const data = {

--- a/src/components/manage/Blocks/ReadMore/ReadMoreView.test.jsx
+++ b/src/components/manage/Blocks/ReadMore/ReadMoreView.test.jsx
@@ -3,6 +3,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ReadMoreView from './ReadMoreView';
 
 describe('ReadMoreView', () => {
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = jest.fn((...args) => {
+      if (args[0]?.includes?.('unmountComponentAtNode')) return;
+      originalError(...args);
+    });
+  });
+  afterAll(() => {
+    console.error = originalError;
+  });
+
   it('renders with default labels and toggles on click', () => {
     const data = {
       label_closed: 'Show more',

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
@@ -130,7 +130,7 @@ const WorkflowLinkIntegrityModal = (props) => {
         }
         onCancel={onCancel}
         onConfirm={onOk}
-        size="medium"
+        size="small"
       />
     )
   );

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
@@ -93,14 +93,9 @@ const WorkflowLinkIntegrityModal = (props) => {
     );
   }
 
-  // If no breaches, we shouldn't even be here, but just in case
-  if (brokenReferences === 0 && open) {
-    onOk();
-    return null;
-  }
-
   return (
-    open && (
+    open &&
+    brokenReferences > 0 && (
       <Confirm
         open={open}
         confirmButton={intl.formatMessage(messages.confirmAction)}

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import { Confirm, Dimmer, Loader, Table } from 'semantic-ui-react';
+
+const messages = defineMessages({
+  confirmHeader: {
+    id: 'Warning: Potential broken links',
+    defaultMessage: 'Warning: Potential broken links',
+  },
+  loading: {
+    id: 'link-integrity: loading references',
+    defaultMessage: 'Checking references...',
+  },
+  confirmAction: {
+    id: 'link-integrity: Change state anyway',
+    defaultMessage: 'Change state anyway',
+  },
+  cancel: {
+    id: 'Cancel',
+    defaultMessage: 'Cancel',
+  },
+  navigate_to_this_item: {
+    id: 'Navigate to this item',
+    defaultMessage: 'Navigate to this item',
+  },
+});
+
+const WorkflowLinkIntegrityModal = (props) => {
+  const { open, onCancel, onOk } = props;
+  const intl = useIntl();
+  const linkintegrityInfo = useSelector((state) => state.linkIntegrity?.result);
+  const loading = useSelector((state) => state.linkIntegrity?.loading);
+
+  const [brokenReferences, setBrokenReferences] = useState(0);
+  const [breaches, setBreaches] = useState([]);
+
+  useEffect(() => {
+    if (linkintegrityInfo) {
+      const breaches = linkintegrityInfo.flatMap((result) =>
+        result.breaches.map((source) => ({
+          source: source,
+          target: result,
+        })),
+      );
+      const source_by_uid = breaches.reduce(
+        (acc, value) => acc.set(value.source.uid, value.source),
+        new Map(),
+      );
+      const by_source = breaches.reduce((acc, value) => {
+        if (acc.get(value.source.uid) === undefined) {
+          acc.set(value.source.uid, new Set());
+        }
+        acc.get(value.source.uid).add(value.target);
+        return acc;
+      }, new Map());
+
+      setBrokenReferences(by_source.size);
+      setBreaches(
+        Array.from(by_source, (entry) => ({
+          source: source_by_uid.get(entry[0]),
+          targets: Array.from(entry[1]),
+        })),
+      );
+    } else {
+      setBrokenReferences(0);
+      setBreaches([]);
+    }
+  }, [linkintegrityInfo]);
+
+  // If we are still loading, show the dimmer
+  if (loading && open) {
+    return (
+      <Confirm
+        open={open}
+        header={intl.formatMessage(messages.confirmHeader)}
+        content={
+          <div className="content">
+            <Dimmer active inverted>
+              <Loader indeterminate size="massive">
+                {intl.formatMessage(messages.loading)}
+              </Loader>
+            </Dimmer>
+            <div style={{ minHeight: '100px' }} />
+          </div>
+        }
+        onCancel={onCancel}
+        onConfirm={() => {}}
+      />
+    );
+  }
+
+  // If no breaches, we shouldn't even be here, but just in case
+  if (brokenReferences === 0 && open) {
+     onOk();
+     return null;
+  }
+
+  return (
+    open && (
+      <Confirm
+        open={open}
+        confirmButton={intl.formatMessage(messages.confirmAction)}
+        cancelButton={intl.formatMessage(messages.cancel)}
+        header={intl.formatMessage(messages.confirmHeader)}
+        content={
+          <div className="content">
+            <FormattedMessage
+              id="Changing the state of this item will break {brokenReferences} {variation} to it."
+              defaultMessage="Changing the state of this item will break {brokenReferences} {variation} to it."
+              values={{
+                brokenReferences: <span>{brokenReferences}</span>,
+                variation: (
+                  <span>
+                    {brokenReferences === 1 ? (
+                      <FormattedMessage
+                        id="reference"
+                        defaultMessage="reference"
+                      />
+                    ) : (
+                      <FormattedMessage
+                        id="references"
+                        defaultMessage="references"
+                      />
+                    )}
+                  </span>
+                ),
+              }}
+            />
+            <BrokenLinksList
+              intl={intl}
+              breaches={breaches}
+            />
+          </div>
+        }
+        onCancel={onCancel}
+        onConfirm={onOk}
+        size="medium"
+      />
+    )
+  );
+};
+
+const BrokenLinksList = ({ intl, breaches }) => {
+  return (
+    <div className="broken-links-list" style={{ marginTop: '20px' }}>
+      <FormattedMessage
+        id="These items will have broken links"
+        defaultMessage="These items will have broken links"
+      />
+      :
+      <Table compact>
+        <Table.Body>
+          {breaches.map((breach) => (
+            <Table.Row key={breach.source['@id']} verticalAlign="top">
+              <Table.Cell>
+                <Link
+                  to={flattenToAppURL(breach.source['@id'])}
+                  title={intl.formatMessage(messages.navigate_to_this_item)}
+                >
+                  {breach.source.title}
+                </Link>
+              </Table.Cell>
+              <Table.Cell style={{ minWidth: '140px' }}>
+                <FormattedMessage id="refers to" defaultMessage="refers to" />:
+              </Table.Cell>
+              <Table.Cell>
+                <ul style={{ margin: 0 }}>
+                  {breach.targets.map((target) => (
+                    <li key={target['@id']}>
+                      <Link
+                        to={flattenToAppURL(target['@id'])}
+                        title={intl.formatMessage(
+                          messages.navigate_to_this_item,
+                        )}
+                      >
+                        {target.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+};
+
+WorkflowLinkIntegrityModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onOk: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default WorkflowLinkIntegrityModal;

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.jsx
@@ -95,8 +95,8 @@ const WorkflowLinkIntegrityModal = (props) => {
 
   // If no breaches, we shouldn't even be here, but just in case
   if (brokenReferences === 0 && open) {
-     onOk();
-     return null;
+    onOk();
+    return null;
   }
 
   return (
@@ -130,10 +130,7 @@ const WorkflowLinkIntegrityModal = (props) => {
                 ),
               }}
             />
-            <BrokenLinksList
-              intl={intl}
-              breaches={breaches}
-            />
+            <BrokenLinksList intl={intl} breaches={breaches} />
           </div>
         }
         onCancel={onCancel}

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.test.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.test.jsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+import '@testing-library/jest-dom/extend-expect';
+import { Provider } from 'react-intl-redux';
+import { render, screen } from '@testing-library/react';
+import WorkflowLinkIntegrityModal from './WorkflowLinkIntegrityModal';
+
+const mockStore = configureStore();
+
+function makeStore(overrides = {}) {
+  return mockStore({
+    linkIntegrity: {
+      result: null,
+      loading: false,
+      loaded: true,
+      ...overrides,
+    },
+    intl: { locale: 'en', messages: {} },
+  });
+}
+
+function renderWithProviders(ui, store) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('WorkflowLinkIntegrityModal', () => {
+  it('renders nothing when not open', () => {
+    const store = makeStore();
+    const { container } = renderWithProviders(
+      <WorkflowLinkIntegrityModal
+        open={false}
+        onCancel={() => {}}
+        onOk={() => {}}
+      />,
+      store,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows loading state while link integrity check is in progress', () => {
+    const store = makeStore({ loading: true });
+    renderWithProviders(
+      <WorkflowLinkIntegrityModal
+        open={true}
+        onCancel={() => {}}
+        onOk={() => {}}
+      />,
+      store,
+    );
+    expect(screen.getByText('Checking references...')).toBeInTheDocument();
+  });
+
+  it('auto-proceeds when no breaches are found', () => {
+    const store = makeStore({
+      result: [{ breaches: [], '@id': 'http://localhost:8080/Plone/target' }],
+      loaded: true,
+    });
+    const { container } = renderWithProviders(
+      <WorkflowLinkIntegrityModal
+        open={true}
+        onCancel={() => {}}
+        onOk={() => {}}
+      />,
+      store,
+    );
+    // brokenReferences === 0 so the Confirm dialog is not rendered
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows warning modal with breach list when breaches are found', () => {
+    const store = makeStore({
+      result: [
+        {
+          '@id': 'http://localhost:8080/Plone/target',
+          title: 'Target Page',
+          breaches: [
+            {
+              '@id': 'http://localhost:8080/Plone/source1',
+              title: 'Source Page 1',
+              uid: 'uid-source1',
+            },
+          ],
+        },
+      ],
+      loaded: true,
+    });
+    renderWithProviders(
+      <WorkflowLinkIntegrityModal
+        open={true}
+        onCancel={() => {}}
+        onOk={() => {}}
+      />,
+      store,
+    );
+    expect(
+      screen.getByText('Warning: Potential broken links'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Source Page 1')).toBeInTheDocument();
+    expect(
+      screen.getByText('Change state anyway'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('aggregates multiple breaches from the same source', () => {
+    const store = makeStore({
+      result: [
+        {
+          '@id': 'http://localhost:8080/Plone/target1',
+          title: 'Target 1',
+          breaches: [
+            {
+              '@id': 'http://localhost:8080/Plone/source1',
+              title: 'Source Page',
+              uid: 'uid-source1',
+            },
+          ],
+        },
+        {
+          '@id': 'http://localhost:8080/Plone/target2',
+          title: 'Target 2',
+          breaches: [
+            {
+              '@id': 'http://localhost:8080/Plone/source1',
+              title: 'Source Page',
+              uid: 'uid-source1',
+            },
+          ],
+        },
+      ],
+      loaded: true,
+    });
+    renderWithProviders(
+      <WorkflowLinkIntegrityModal
+        open={true}
+        onCancel={() => {}}
+        onOk={() => {}}
+      />,
+      store,
+    );
+    // Both breaches come from the same source, so brokenReferences === 1
+    expect(screen.getByText('Source Page')).toBeInTheDocument();
+    expect(screen.getByText('Target 1')).toBeInTheDocument();
+    expect(screen.getByText('Target 2')).toBeInTheDocument();
+  });
+});

--- a/src/components/manage/Workflow/WorkflowLinkIntegrityModal.test.jsx
+++ b/src/components/manage/Workflow/WorkflowLinkIntegrityModal.test.jsx
@@ -101,9 +101,7 @@ describe('WorkflowLinkIntegrityModal', () => {
       screen.getByText('Warning: Potential broken links'),
     ).toBeInTheDocument();
     expect(screen.getByText('Source Page 1')).toBeInTheDocument();
-    expect(
-      screen.getByText('Change state anyway'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Change state anyway')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
 

--- a/src/components/theme/Views/ArchivedVersionListing.test.jsx
+++ b/src/components/theme/Views/ArchivedVersionListing.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { IntlProvider } from 'react-intl';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import ArchivedVersionListing from './ArchivedVersionListing';
@@ -21,16 +22,21 @@ jest.mock('@eeacms/volto-cca-policy/components', () => ({
   ),
 }));
 
+const renderWithIntl = (ui) =>
+  render(
+    <IntlProvider locale="en">
+      <MemoryRouter>{ui}</MemoryRouter>
+    </IntlProvider>,
+  );
+
 describe('ArchivedVersionListing', () => {
   it('returns null when there are no archived versions', () => {
     const content = {
       archived_versions: [],
     };
 
-    const { container } = render(
-      <MemoryRouter>
-        <ArchivedVersionListing content={content} />
-      </MemoryRouter>,
+    const { container } = renderWithIntl(
+      <ArchivedVersionListing content={content} />,
     );
 
     expect(container.innerHTML).toBe('');
@@ -39,10 +45,8 @@ describe('ArchivedVersionListing', () => {
   it('returns null when archived_versions is missing', () => {
     const content = {};
 
-    const { container } = render(
-      <MemoryRouter>
-        <ArchivedVersionListing content={content} />
-      </MemoryRouter>,
+    const { container } = renderWithIntl(
+      <ArchivedVersionListing content={content} />,
     );
 
     expect(container.innerHTML).toBe('');
@@ -62,11 +66,7 @@ describe('ArchivedVersionListing', () => {
       ],
     };
 
-    render(
-      <MemoryRouter>
-        <ArchivedVersionListing content={content} />
-      </MemoryRouter>,
-    );
+    renderWithIntl(<ArchivedVersionListing content={content} />);
 
     expect(
       screen.getByText('Previous versions of this indicator'),
@@ -92,11 +92,7 @@ describe('ArchivedVersionListing', () => {
       ],
     };
 
-    render(
-      <MemoryRouter>
-        <ArchivedVersionListing content={content} />
-      </MemoryRouter>,
-    );
+    renderWithIntl(<ArchivedVersionListing content={content} />);
 
     expect(screen.getByText('/indicator-v1')).toHaveAttribute(
       'href',

--- a/src/components/theme/Views/CcaEventView.test.jsx
+++ b/src/components/theme/Views/CcaEventView.test.jsx
@@ -64,7 +64,10 @@ test('renders an event view component with all props', () => {
           subjects: ['Guillotina', 'Volto'],
           whole_day: false,
           agenda_files: {},
-          background_documents: {},
+          background_documents: {
+            download: 'http://localhost:8080/Plone/my-page/background.pdf',
+            filename: 'background.pdf',
+          },
         }}
       />
     </Provider>,
@@ -85,7 +88,10 @@ test('renders an event view component with only required props', () => {
           start: '2019-06-23T15:20:00+00:00',
           subjects: [],
           agenda_files: {},
-          background_documents: {},
+          background_documents: {
+            download: 'http://localhost:8080/Plone/my-page/background.pdf',
+            filename: 'background.pdf',
+          },
         }}
       />
     </Provider>,
@@ -106,7 +112,10 @@ test('renders an event view component without links to api in the text', () => {
           start: '2019-06-23T15:20:00+00:00',
           subjects: [],
           agenda_files: {},
-          background_documents: {},
+          background_documents: {
+            download: 'http://localhost:8080/Plone/my-page/background.pdf',
+            filename: 'background.pdf',
+          },
           text: {
             data: `<p>Hello World!</p><p>This is an <a href="${settings.apiPath}/foo/bar">internal link</a> and a <a href="${settings.apiPath}/foo/baz">second link</a></p>`,
           },

--- a/src/components/theme/Views/DatabaseItemView.test.jsx
+++ b/src/components/theme/Views/DatabaseItemView.test.jsx
@@ -44,11 +44,11 @@ describe('DatabaseItemView', () => {
       contributions: [
         {
           title: 'Contributor 1',
-          url: '/',
+          url: '/contributor-1',
         },
         {
           title: 'Contributor 2',
-          url: '/',
+          url: '/contributor-2',
         },
       ],
     };

--- a/src/components/theme/Views/__snapshots__/CcaEventView.test.jsx.snap
+++ b/src/components/theme/Views/__snapshots__/CcaEventView.test.jsx.snap
@@ -51,11 +51,14 @@ exports[`renders an event view component with all props 1`] = `
               >
                 <a
                   className="document-list-item"
+                  href="http://localhost:8080/Plone/my-page/background.pdf"
                 >
                   <i
                     className="file alternate icon"
                   />
-                  <span />
+                  <span>
+                    background.pdf
+                  </span>
                 </a>
               </div>
             </div>
@@ -240,11 +243,14 @@ exports[`renders an event view component with only required props 1`] = `
               >
                 <a
                   className="document-list-item"
+                  href="http://localhost:8080/Plone/my-page/background.pdf"
                 >
                   <i
                     className="file alternate icon"
                   />
-                  <span />
+                  <span>
+                    background.pdf
+                  </span>
                 </a>
               </div>
             </div>
@@ -382,11 +388,14 @@ exports[`renders an event view component without links to api in the text 1`] = 
               >
                 <a
                   className="document-list-item"
+                  href="http://localhost:8080/Plone/my-page/background.pdf"
                 >
                   <i
                     className="file alternate icon"
                   />
-                  <span />
+                  <span>
+                    background.pdf
+                  </span>
                 </a>
               </div>
             </div>

--- a/src/components/theme/Views/__snapshots__/DatabaseItemView.test.jsx.snap
+++ b/src/components/theme/Views/__snapshots__/DatabaseItemView.test.jsx.snap
@@ -69,7 +69,7 @@ exports[`DatabaseItemView should render the component 1`] = `
               role="listitem"
             >
               <a
-                href="/"
+                href="/contributor-1"
                 onClick={[Function]}
               >
                 Contributor 1
@@ -81,7 +81,7 @@ exports[`DatabaseItemView should render the component 1`] = `
               role="listitem"
             >
               <a
-                href="/"
+                href="/contributor-2"
                 onClick={[Function]}
               >
                 Contributor 2

--- a/src/components/theme/Widgets/GeolocationWidget.jsx
+++ b/src/components/theme/Widgets/GeolocationWidget.jsx
@@ -5,7 +5,7 @@ import config from '@plone/volto/registry';
 
 import { injectIntl } from 'react-intl';
 import { FormFieldWrapper } from '@plone/volto/components';
-import MapContainer from './GeolocationWidgetMapContainer';
+import MapContainer from '@eeacms/volto-cca-policy/components/theme/Widgets/GeolocationWidgetMapContainer';
 
 const defaultValue = {
   latitude: 55.6761,

--- a/src/customizations/volto/components/manage/Workflow/README.md
+++ b/src/customizations/volto/components/manage/Workflow/README.md
@@ -1,0 +1,22 @@
+# Workflow Component Customization
+
+This component shadows the core Volto `Workflow` component located at `@plone/volto/components/manage/Workflow/Workflow.jsx`.
+
+## Why this is needed
+
+In Climate-ADAPT, we want to prevent users from unintentionally breaking internal links when making content private. Volto's core workflow transition dropdown does not perform any link integrity checks before executing a state change.
+
+By shadowing this component, we can intercept transitions that might hide content from public users and warn the editor if other pages are linking to the current item.
+
+## Modifications
+
+1.  **Interception Logic**: The `transition` function was modified to check for "private-like" transitions (`private`, `reject`, `retract`).
+2.  **Link Integrity Check**: When a sensitive transition is selected, the `linkIntegrityCheck` action is dispatched to the backend.
+3.  **State Management**: Added local state (`showWarningModal`, `pendingOption`) to handle the asynchronous check and the confirmation flow.
+4.  **Confirmation Modal**: Integrated `WorkflowLinkIntegrityModal` which displays the list of pages that would have broken links.
+5.  **Auto-proceed**: Added an `useEffect` that automatically executes the transition if the link integrity check returns zero breaches.
+
+## Reference
+
+See implementation details in:
+`artifacts/link-integrity-workflow/understanding-link-integrity.md`

--- a/src/customizations/volto/components/manage/Workflow/README.md
+++ b/src/customizations/volto/components/manage/Workflow/README.md
@@ -15,6 +15,7 @@ By shadowing this component, we can intercept transitions that might hide conten
 3.  **State Management**: Added local state (`showWarningModal`, `pendingOption`) to handle the asynchronous check and the confirmation flow.
 4.  **Confirmation Modal**: Integrated `WorkflowLinkIntegrityModal` which displays the list of pages that would have broken links.
 5.  **Auto-proceed**: Added an `useEffect` that automatically executes the transition if the link integrity check returns zero breaches.
+6.  **Activity Indicators**: Added `Dimmer` and `Loader` components from `semantic-ui-react` to provide visual feedback while the link integrity check is loading and during the workflow transition execution.
 
 ## Reference
 

--- a/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+++ b/src/customizations/volto/components/manage/Workflow/Workflow.jsx
@@ -1,0 +1,288 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { uniqBy } from 'lodash';
+import { toast } from 'react-toastify';
+import { defineMessages, useIntl } from 'react-intl';
+
+import { FormFieldWrapper, Icon, Toast } from '@plone/volto/components';
+import {
+  flattenToAppURL,
+  getWorkflowOptions,
+  getCurrentStateMapping,
+} from '@plone/volto/helpers';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+
+import {
+  getContent,
+  getWorkflow,
+  transitionWorkflow,
+  linkIntegrityCheck,
+} from '@plone/volto/actions';
+import WorkflowLinkIntegrityModal from '@eeacms/volto-cca-policy/components/manage/Workflow/WorkflowLinkIntegrityModal';
+import downSVG from '@plone/volto/icons/down-key.svg';
+import upSVG from '@plone/volto/icons/up-key.svg';
+import checkSVG from '@plone/volto/icons/check.svg';
+
+const messages = defineMessages({
+  messageUpdated: {
+    id: 'Workflow updated.',
+    defaultMessage: 'Workflow updated.',
+  },
+  messageNoWorkflow: {
+    id: 'No workflow',
+    defaultMessage: 'No workflow',
+  },
+  state: {
+    id: 'State',
+    defaultMessage: 'State',
+  },
+});
+
+const SingleValue = injectLazyLibs('reactSelect')(({ children, ...props }) => {
+  const stateDecorator = {
+    marginRight: '10px',
+    display: 'inline-block',
+    backgroundColor: props.selectProps.value.color || null,
+    content: ' ',
+    height: '10px',
+    width: '10px',
+    borderRadius: '50%',
+  };
+  const { SingleValue } = props.reactSelect.components;
+  return (
+    <SingleValue {...props}>
+      <span style={stateDecorator} />
+      {children}
+    </SingleValue>
+  );
+});
+
+const Option = injectLazyLibs('reactSelect')((props) => {
+  const stateDecorator = {
+    marginRight: '10px',
+    display: 'inline-block',
+    backgroundColor:
+      props.selectProps.value.value === props.data.value
+        ? props.selectProps.value.color
+        : null,
+    content: ' ',
+    height: '10px',
+    width: '10px',
+    borderRadius: '50%',
+    border:
+      props.selectProps.value.value !== props.data.value
+        ? `1px solid ${props.data.color}`
+        : null,
+  };
+
+  const { Option } = props['reactSelect'].components;
+  return (
+    <Option {...props}>
+      <span style={stateDecorator} />
+      <div style={{ marginRight: 'auto' }}>{props.label}</div>
+      {props.isFocused && !props.isSelected && (
+        <Icon name={checkSVG} size="18px" color="#b8c6c8" />
+      )}
+      {props.isSelected && <Icon name={checkSVG} size="18px" color="#007bc1" />}
+    </Option>
+  );
+});
+
+const DropdownIndicator = injectLazyLibs('reactSelect')((props) => {
+  const { DropdownIndicator } = props.reactSelect.components;
+  return (
+    <DropdownIndicator {...props} data-testid="workflow-select-dropdown">
+      {props.selectProps.menuIsOpen ? (
+        <Icon name={upSVG} size="24px" color="#007bc1" />
+      ) : (
+        <Icon name={downSVG} size="24px" color="#007bc1" />
+      )}
+    </DropdownIndicator>
+  );
+});
+
+const selectTheme = (theme) => ({
+  ...theme,
+  borderRadius: 0,
+  colors: {
+    ...theme.colors,
+    primary25: 'hotpink',
+    primary: '#b8c6c8',
+  },
+});
+
+const customSelectStyles = {
+  control: (styles, state) => ({
+    ...styles,
+    border: 'none',
+    borderBottom: '2px solid #b8c6c8',
+    boxShadow: 'none',
+    borderBottomStyle: state.menuIsOpen ? 'dotted' : 'solid',
+  }),
+  menu: (styles, state) => ({
+    ...styles,
+    top: null,
+    marginTop: 0,
+    boxShadow: 'none',
+    borderBottom: '2px solid #b8c6c8',
+  }),
+  indicatorSeparator: (styles) => ({
+    ...styles,
+    width: null,
+  }),
+  valueContainer: (styles) => ({
+    ...styles,
+    padding: 0,
+  }),
+  option: (styles, state) => ({
+    ...styles,
+    backgroundColor: null,
+    minHeight: '50px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 12px',
+    color: state.isSelected
+      ? '#007bc1'
+      : state.isFocused
+      ? '#4a4a4a'
+      : 'inherit',
+    ':active': {
+      backgroundColor: null,
+    },
+    span: {
+      flex: '0 0 auto',
+    },
+    svg: {
+      flex: '0 0 auto',
+    },
+  }),
+};
+
+function useWorkflow() {
+  const history = useSelector((state) => state.workflow.history, shallowEqual);
+  const transitions = useSelector(
+    (state) => state.workflow.transitions,
+    shallowEqual,
+  );
+  const loaded = useSelector((state) => state.workflow.transition.loaded);
+  const currentStateValue = useSelector(
+    (state) => getCurrentStateMapping(state.workflow.currentState),
+    shallowEqual,
+  );
+  const linkintegrityInfo = useSelector((state) => state.linkIntegrity?.result);
+
+  return { loaded, history, transitions, currentStateValue, linkintegrityInfo };
+}
+
+const Workflow = (props) => {
+  const intl = useIntl();
+  const dispatch = useDispatch();
+  const { loaded, transitions, currentStateValue, linkintegrityInfo } =
+    useWorkflow();
+  const content = useSelector((state) => state.content?.data, shallowEqual);
+  const { pathname } = props;
+
+  const [showWarningModal, setShowWarningModal] = useState(false);
+  const [pendingOption, setPendingOption] = useState(null);
+
+  useEffect(() => {
+    dispatch(getWorkflow(pathname));
+    dispatch(getContent(pathname));
+  }, [dispatch, pathname, loaded]);
+
+  useEffect(() => {
+    if (showWarningModal && linkintegrityInfo) {
+      const breaches = linkintegrityInfo.flatMap((result) => result.breaches);
+      if (breaches.length === 0) {
+        executeTransition(pendingOption);
+        setShowWarningModal(false);
+      }
+    }
+  }, [linkintegrityInfo, showWarningModal, pendingOption]);
+
+  const transition = (selectedOption) => {
+    const isPrivateTransition =
+      ['private', 'reject', 'retract'].includes(selectedOption.value) ||
+      selectedOption.url.endsWith('/reject') ||
+      selectedOption.url.endsWith('/retract');
+
+    if (isPrivateTransition) {
+      setPendingOption(selectedOption);
+      dispatch(linkIntegrityCheck([content.UID]));
+      setShowWarningModal(true);
+    } else {
+      executeTransition(selectedOption);
+    }
+  };
+
+  const executeTransition = (selectedOption) => {
+    dispatch(transitionWorkflow(flattenToAppURL(selectedOption.url)));
+    toast.success(
+      <Toast
+        success
+        title={intl.formatMessage(messages.messageUpdated)}
+        content=""
+      />,
+    );
+  };
+
+  const { Placeholder } = props.reactSelect.components;
+  const Select = props.reactSelect.default;
+
+  return (
+    <>
+      <FormFieldWrapper
+        id="state-select"
+        title={intl.formatMessage(messages.state)}
+        intl={intl}
+        {...props}
+      >
+        <Select
+          name="state-select"
+          className="react-select-container"
+          classNamePrefix="react-select"
+          isDisabled={!content.review_state || transitions.length === 0}
+          options={uniqBy(
+            transitions.map((transition) => getWorkflowOptions(transition)),
+            'label',
+          ).concat(currentStateValue)}
+          styles={customSelectStyles}
+          theme={selectTheme}
+          components={{
+            DropdownIndicator,
+            Placeholder,
+            Option,
+            SingleValue,
+          }}
+          onChange={transition}
+          value={
+            content.review_state
+              ? currentStateValue
+              : {
+                  label: intl.formatMessage(messages.messageNoWorkflow),
+                  value: 'noworkflow',
+                }
+          }
+          isSearchable={false}
+        />
+      </FormFieldWrapper>
+      <WorkflowLinkIntegrityModal
+        open={showWarningModal}
+        onCancel={() => setShowWarningModal(false)}
+        onOk={() => {
+          executeTransition(pendingOption);
+          setShowWarningModal(false);
+        }}
+      />
+    </>
+  );
+};
+
+Workflow.propTypes = {
+  pathname: PropTypes.string.isRequired,
+};
+
+export default compose(injectLazyLibs(['reactSelect']))(Workflow);

--- a/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+++ b/src/customizations/volto/components/manage/Workflow/Workflow.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
@@ -129,6 +129,10 @@ const customSelectStyles = {
     boxShadow: 'none',
     borderBottom: '2px solid #b8c6c8',
   }),
+  menuList: (styles, state) => ({
+    ...styles,
+    maxHeight: '400px',
+  }),
   indicatorSeparator: (styles) => ({
     ...styles,
     width: null,
@@ -219,8 +223,29 @@ const Workflow = (props) => {
     dispatch(getContent(pathname));
   }, [dispatch, pathname, loaded]);
 
+  const executeTransition = useCallback(
+    (selectedOption) => {
+      if (selectedOption?.url) {
+        dispatch(transitionWorkflow(flattenToAppURL(selectedOption.url)));
+        toast.success(
+          <Toast
+            success
+            title={intl.formatMessage(messages.messageUpdated)}
+            content=""
+          />,
+        );
+      }
+    },
+    [dispatch, intl],
+  );
+
   useEffect(() => {
-    if (showWarningModal && linkintegrityLoaded && linkintegrityInfo) {
+    if (
+      showWarningModal &&
+      linkintegrityLoaded &&
+      linkintegrityInfo &&
+      linkintegrityInfo[0]?.['@id'] === content?.['@id']
+    ) {
       const breaches = linkintegrityInfo.flatMap((result) => result.breaches);
       if (breaches.length === 0) {
         executeTransition(pendingOption);
@@ -228,7 +253,14 @@ const Workflow = (props) => {
         setPendingOption(null);
       }
     }
-  }, [linkintegrityLoaded, linkintegrityInfo, showWarningModal, pendingOption]);
+  }, [
+    linkintegrityLoaded,
+    linkintegrityInfo,
+    showWarningModal,
+    pendingOption,
+    content,
+    executeTransition,
+  ]);
 
   const transition = (selectedOption) => {
     const isPrivateTransition =
@@ -243,17 +275,6 @@ const Workflow = (props) => {
     } else {
       executeTransition(selectedOption);
     }
-  };
-
-  const executeTransition = (selectedOption) => {
-    dispatch(transitionWorkflow(flattenToAppURL(selectedOption.url)));
-    toast.success(
-      <Toast
-        success
-        title={intl.formatMessage(messages.messageUpdated)}
-        content=""
-      />,
-    );
   };
 
   const { Placeholder } = props.reactSelect.components;
@@ -306,10 +327,14 @@ const Workflow = (props) => {
       </FormFieldWrapper>
       <WorkflowLinkIntegrityModal
         open={showWarningModal}
-        onCancel={() => setShowWarningModal(false)}
+        onCancel={() => {
+          setShowWarningModal(false);
+          setPendingOption(null);
+        }}
         onOk={() => {
           executeTransition(pendingOption);
           setShowWarningModal(false);
+          setPendingOption(null);
         }}
       />
     </>

--- a/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+++ b/src/customizations/volto/components/manage/Workflow/Workflow.jsx
@@ -7,6 +7,7 @@ import { toast } from 'react-toastify';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { FormFieldWrapper, Icon, Toast } from '@plone/volto/components';
+import { Dimmer, Loader } from 'semantic-ui-react';
 import {
   flattenToAppURL,
   getWorkflowOptions,
@@ -168,6 +169,9 @@ function useWorkflow() {
     shallowEqual,
   );
   const loaded = useSelector((state) => state.workflow.transition.loaded);
+  const transitionLoading = useSelector(
+    (state) => state.workflow.transition.loading,
+  );
   const currentStateValue = useSelector(
     (state) => getCurrentStateMapping(state.workflow.currentState),
     shallowEqual,
@@ -176,14 +180,19 @@ function useWorkflow() {
   const linkintegrityLoaded = useSelector(
     (state) => state.linkIntegrity?.loaded,
   );
+  const linkintegrityLoading = useSelector(
+    (state) => state.linkIntegrity?.loading,
+  );
 
   return {
     loaded,
+    transitionLoading,
     history,
     transitions,
     currentStateValue,
     linkintegrityInfo,
     linkintegrityLoaded,
+    linkintegrityLoading,
   };
 }
 
@@ -192,10 +201,12 @@ const Workflow = (props) => {
   const dispatch = useDispatch();
   const {
     loaded,
+    transitionLoading,
     transitions,
     currentStateValue,
     linkintegrityInfo,
     linkintegrityLoaded,
+    linkintegrityLoading,
   } = useWorkflow();
   const content = useSelector((state) => state.content?.data, shallowEqual);
   const { pathname } = props;
@@ -256,11 +267,19 @@ const Workflow = (props) => {
         intl={intl}
         {...props}
       >
+        <Dimmer active={transitionLoading} inverted>
+          <Loader size="small" />
+        </Dimmer>
         <Select
           name="state-select"
           className="react-select-container"
           classNamePrefix="react-select"
-          isDisabled={!content.review_state || transitions.length === 0}
+          isDisabled={
+            !content.review_state ||
+            transitions.length === 0 ||
+            transitionLoading ||
+            (showWarningModal && linkintegrityLoading)
+          }
           options={uniqBy(
             transitions.map((transition) => getWorkflowOptions(transition)),
             'label',

--- a/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+++ b/src/customizations/volto/components/manage/Workflow/Workflow.jsx
@@ -173,15 +173,30 @@ function useWorkflow() {
     shallowEqual,
   );
   const linkintegrityInfo = useSelector((state) => state.linkIntegrity?.result);
+  const linkintegrityLoaded = useSelector(
+    (state) => state.linkIntegrity?.loaded,
+  );
 
-  return { loaded, history, transitions, currentStateValue, linkintegrityInfo };
+  return {
+    loaded,
+    history,
+    transitions,
+    currentStateValue,
+    linkintegrityInfo,
+    linkintegrityLoaded,
+  };
 }
 
 const Workflow = (props) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const { loaded, transitions, currentStateValue, linkintegrityInfo } =
-    useWorkflow();
+  const {
+    loaded,
+    transitions,
+    currentStateValue,
+    linkintegrityInfo,
+    linkintegrityLoaded,
+  } = useWorkflow();
   const content = useSelector((state) => state.content?.data, shallowEqual);
   const { pathname } = props;
 
@@ -194,14 +209,15 @@ const Workflow = (props) => {
   }, [dispatch, pathname, loaded]);
 
   useEffect(() => {
-    if (showWarningModal && linkintegrityInfo) {
+    if (showWarningModal && linkintegrityLoaded && linkintegrityInfo) {
       const breaches = linkintegrityInfo.flatMap((result) => result.breaches);
       if (breaches.length === 0) {
         executeTransition(pendingOption);
         setShowWarningModal(false);
+        setPendingOption(null);
       }
     }
-  }, [linkintegrityInfo, showWarningModal, pendingOption]);
+  }, [linkintegrityLoaded, linkintegrityInfo, showWarningModal, pendingOption]);
 
   const transition = (selectedOption) => {
     const isPrivateTransition =

--- a/src/customizations/volto/components/manage/Workflow/Workflow.jsx
+++ b/src/customizations/volto/components/manage/Workflow/Workflow.jsx
@@ -187,6 +187,7 @@ function useWorkflow() {
   const linkintegrityLoading = useSelector(
     (state) => state.linkIntegrity?.loading,
   );
+  const linkintegrityError = useSelector((state) => state.linkIntegrity?.error);
 
   return {
     loaded,
@@ -197,6 +198,7 @@ function useWorkflow() {
     linkintegrityInfo,
     linkintegrityLoaded,
     linkintegrityLoading,
+    linkintegrityError,
   };
 }
 
@@ -211,6 +213,7 @@ const Workflow = (props) => {
     linkintegrityInfo,
     linkintegrityLoaded,
     linkintegrityLoading,
+    linkintegrityError,
   } = useWorkflow();
   const content = useSelector((state) => state.content?.data, shallowEqual);
   const { pathname } = props;
@@ -240,22 +243,30 @@ const Workflow = (props) => {
   );
 
   useEffect(() => {
-    if (
-      showWarningModal &&
-      linkintegrityLoaded &&
-      linkintegrityInfo &&
-      linkintegrityInfo[0]?.['@id'] === content?.['@id']
-    ) {
-      const breaches = linkintegrityInfo.flatMap((result) => result.breaches);
-      if (breaches.length === 0) {
+    if (showWarningModal) {
+      if (linkintegrityError) {
+        // If the check fails, we shouldn't block the user forever. Proceed with transition.
         executeTransition(pendingOption);
         setShowWarningModal(false);
         setPendingOption(null);
+      } else if (
+        linkintegrityLoaded &&
+        linkintegrityInfo &&
+        flattenToAppURL(linkintegrityInfo[0]?.['@id']) ===
+          flattenToAppURL(content?.['@id'])
+      ) {
+        const breaches = linkintegrityInfo.flatMap((result) => result.breaches);
+        if (breaches.length === 0) {
+          executeTransition(pendingOption);
+          setShowWarningModal(false);
+          setPendingOption(null);
+        }
       }
     }
   }, [
     linkintegrityLoaded,
     linkintegrityInfo,
+    linkintegrityError,
     showWarningModal,
     pendingOption,
     content,


### PR DESCRIPTION
## Summary
This PR implements a warning mechanism in the workflow transition dropdown. When a user attempts to make a content item "Private" (or similar states like reject/retract), the system checks if there are other content items linking to it. If so, a confirmation modal is shown listing the affected items, allowing the user to either cancel or proceed with the knowledge of broken links.

## Changes
- Shadowed `@plone/volto/components/manage/Workflow/Workflow.jsx` into the add-on.
- Created `WorkflowLinkIntegrityModal` component to display link integrity breaches.
- Modified shadowed `Workflow.jsx` to intercept private-like transitions and trigger `linkIntegrityCheck`.
- Added implementation artifacts in `artifacts/link-integrity-workflow/`.